### PR TITLE
Multiple model generator when using wildcard * as table name bug fix

### DIFF
--- a/AweModel/AweModelCode.php
+++ b/AweModel/AweModelCode.php
@@ -57,6 +57,7 @@ class AweModelCode extends ModelCode {
 
         $this->relations = $this->generateRelations();
 
+        $this->files = array();
         foreach ($this->tables as $table) {
 
             foreach ($table->columns as $key => $column)
@@ -78,8 +79,7 @@ class AweModelCode extends ModelCode {
                 'rules' => $this->generateRules($table),
                 'relations' => isset($this->relations[$className]) ? $this->relations[$className] : array(),
             );
-
-            $this->files = array();
+            
             $this->files[] = new CCodeFile(
                             Yii::getPathOfAlias($this->modelPath . '.' . $className) . '.php',
                             $this->render($templatePath . DIRECTORY_SEPARATOR . 'model.php', $params)


### PR DESCRIPTION
Hi,

I just fixed a bug in AweModelCode.php .
Whene setting a wildcard (*) as tableName in model generator only the last one was previewed and generated .
The $files properties was reinit in tables the iteration in prepare() method , i juste moved the init of the $files before the loop . 
